### PR TITLE
change the links of crypto and ssl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ add_compile_definitions(BOOST_COROUTINES_NO_DEPRECATION_WARNING)
 
 find_package(Boost 1.68.0 REQUIRED COMPONENTS system context coroutine log regex)
 find_package(nlohmann_json 3.3.0 REQUIRED)
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL 1.1.0 REQUIRED)
 find_package(Threads REQUIRED)
 
 file(GLOB SHARED_SRC_LIST shared/*.cpp)
@@ -27,23 +27,23 @@ add_executable(niba-server ${SERVER_SRC_LIST} ${SHARED_SRC_LIST})
 add_executable(niba-client ${CLIENT_SRC_LIST} ${SHARED_SRC_LIST})
 
 target_link_libraries(niba-server
+    ${OPENSSL_CRYPTO_LIBRARY}
+    ${OPENSSL_SSL_LIBRARY}
     Boost::system
     Boost::context
     Boost::coroutine
     Boost::log
     Boost::regex
-    crypto
-    ssl
     Threads::Threads
     nlohmann_json::nlohmann_json)
 
 target_link_libraries(niba-client
+    ${OPENSSL_CRYPTO_LIBRARY}
+    ${OPENSSL_SSL_LIBRARY}
     Boost::system
     Boost::context
     Boost::coroutine
     Boost::log
     Boost::regex
-    crypto
-    ssl
     Threads::Threads 
     nlohmann_json::nlohmann_json)


### PR DESCRIPTION
Using crypto and ssl gives the errors "library -lcrypto not found" and "-lssl not found".  The libraries are not correctly linked for some unknown reason. However, once find_package successfully finds OpenSSL, ${OPENSSL_CRYPTO_LIBRARY} and ${OPENSSL_SSL_LIBRARY} must be correct relative paths. This may be a better way to define target_link_libraries.