### PR TITLE
hide connector type so we can add ozo::register_types easier

### DIFF
--- a/server/connector.h
+++ b/server/connector.h
@@ -6,6 +6,7 @@
 #include <ozo/execute.h>
 #include <ozo/request.h>
 #include <ozo/shortcuts.h>
+#include <type_traits>
 
 namespace nibaserver {
 
@@ -14,7 +15,8 @@ inline auto make_ozo_connector(boost::asio::io_context &ioc) {
     // note these are static so they still exists after we return from this function
     static auto connection_info = ozo::make_connection_info("dbname=niba user=postgres");
     ozo::connection_pool_config connection_pool_config;
-    static auto connection_pool = ozo::make_connection_pool(connection_info, connection_pool_config);
+    static auto connection_pool =
+        ozo::make_connection_pool(connection_info, connection_pool_config);
     // Creating connection pool from connection_info as the underlying ConnectionSource
     static ozo::connection_pool_timeouts timeouts;
 

--- a/server/connector.h
+++ b/server/connector.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <ozo/connection.h>
+#include <ozo/connection_info.h>
+#include <ozo/connection_pool.h>
+#include <ozo/execute.h>
+#include <ozo/request.h>
+#include <ozo/shortcuts.h>
+
+namespace nibaserver {
+
+// we use this just to get around needing to write out the type for the connector
+inline auto make_ozo_connector(boost::asio::io_context &ioc) {
+    // note these are static so they still exists after we return from this function
+    static auto connection_info = ozo::make_connection_info("dbname=niba user=postgres");
+    ozo::connection_pool_config connection_pool_config;
+    static auto connection_pool = ozo::make_connection_pool(connection_info, connection_pool_config);
+    // Creating connection pool from connection_info as the underlying ConnectionSource
+    static ozo::connection_pool_timeouts timeouts;
+
+    // Maximum limit for number of stored connections
+    connection_pool_config.capacity = 100;
+    // Maximum limit for number of waiting requests for connection
+    connection_pool_config.queue_capacity = 5000;
+    // Maximum time duration to store unused open connection
+    connection_pool_config.idle_timeout = std::chrono::seconds(60);
+
+    timeouts.connect = std::chrono::seconds(10);
+    timeouts.queue = std::chrono::seconds(10);
+
+    return ozo::make_connector(connection_pool, ioc, timeouts);
+}
+
+using niba_ozo_connector =
+    std::result_of<decltype (&make_ozo_connector)(boost::asio::io_context &)>::type;
+
+} // namespace nibaserver

--- a/server/connector.h
+++ b/server/connector.h
@@ -14,7 +14,7 @@ namespace nibaserver {
 inline auto make_ozo_connector(boost::asio::io_context &ioc) {
     // note these are static so they still exist after we return from this function
     static auto connection_info = ozo::make_connection_info("dbname=niba user=postgres");
-    ozo::connection_pool_config connection_pool_config;
+    static ozo::connection_pool_config connection_pool_config;
     static auto connection_pool =
         ozo::make_connection_pool(connection_info, connection_pool_config);
     // Creating connection pool from connection_info as the underlying ConnectionSource
@@ -34,6 +34,6 @@ inline auto make_ozo_connector(boost::asio::io_context &ioc) {
 }
 
 using niba_ozo_connector =
-    std::invoke_result_t<decltype(&make_ozo_connector), boost::asio::io_context&>;
+    std::invoke_result_t<decltype(&make_ozo_connector), boost::asio::io_context &>;
 
 } // namespace nibaserver

--- a/server/connector.h
+++ b/server/connector.h
@@ -34,6 +34,6 @@ inline auto make_ozo_connector(boost::asio::io_context &ioc) {
 }
 
 using niba_ozo_connector =
-    std::result_of<decltype (&make_ozo_connector)(boost::asio::io_context &)>::type;
+    std::invoke_result_t<decltype(&make_ozo_connector), boost::asio::io_context&>;
 
 } // namespace nibaserver

--- a/server/connector.h
+++ b/server/connector.h
@@ -12,7 +12,7 @@ namespace nibaserver {
 
 // we use this just to get around needing to write out the type for the connector
 inline auto make_ozo_connector(boost::asio::io_context &ioc) {
-    // note these are static so they still exists after we return from this function
+    // note these are static so they still exist after we return from this function
     static auto connection_info = ozo::make_connection_info("dbname=niba user=postgres");
     ozo::connection_pool_config connection_pool_config;
     static auto connection_pool =

--- a/server/db_accessor.cpp
+++ b/server/db_accessor.cpp
@@ -16,8 +16,7 @@ namespace sev = boost::log::trivial;
 
 constexpr std::size_t HASH_SIZE = 32;
 
-db_accessor::db_accessor(const ozo::connector<ozo::connection_pool<ozo::connection_info<>>,
-                                              ozo::connection_pool_timeouts> &conn) :
+db_accessor::db_accessor(const niba_ozo_connector &conn) :
     conn_(conn) {
     logger_ = logger();
 }

--- a/server/db_accessor.h
+++ b/server/db_accessor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "connector.h"
 #include "logger.h"
 #include "structs.h"
 #include <boost/asio/spawn.hpp>
@@ -9,6 +10,7 @@
 #include <ozo/connection_pool.h>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -53,8 +55,7 @@ public:
 
 private:
     logger logger_;
-    const ozo::connector<ozo::connection_pool<ozo::connection_info<>>,
-                         ozo::connection_pool_timeouts> &conn_;
+    const niba_ozo_connector &conn_;
 };
 
 } // namespace nibaserver

--- a/server/db_accessor.h
+++ b/server/db_accessor.h
@@ -10,7 +10,6 @@
 #include <ozo/connection_pool.h>
 #include <string>
 #include <string_view>
-#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -35,6 +35,7 @@
 // #include <vector>
 
 #include "cert_loader.hpp"
+#include "connector.h"
 #include "db_accessor.h"
 #include "gamedata.h"
 #include "logger.h"
@@ -103,8 +104,10 @@ int main(int argc, char *argv[]) {
 
     init_log();
     logger logger;
+    BOOST_LOG_SEV(logger, sev::info) << "Server starts.";
 
     init_gamedata();
+    BOOST_LOG_SEV(logger, sev::info) << "Game data loaded.";
 
     // The io_context is required for all I/O
     boost::asio::io_context ioc{threads};
@@ -114,29 +117,7 @@ int main(int argc, char *argv[]) {
 
     // This holds the self-signed certificate used by the server
     load_server_certificate(ctx);
-
-    BOOST_LOG_SEV(logger, sev::info) << "Server starts.";
-
-    // Spawn a listening port, note as per clang, &port is not required in capture list as its
-    // a constexpr
-
-    auto connection_info = ozo::make_connection_info("dbname=niba user=postgres");
-
-    ozo::connection_pool_config connection_pool_config;
-
-    // Maximum limit for number of stored connections
-    connection_pool_config.capacity = 100;
-    // Maximum limit for number of waiting requests for connection
-    connection_pool_config.queue_capacity = 5000;
-    // Maximum time duration to store unused open connection
-    connection_pool_config.idle_timeout = std::chrono::seconds(60);
-
-    // Creating connection pool from connection_info as the underlying ConnectionSource
-    auto connection_pool = ozo::make_connection_pool(connection_info, connection_pool_config);
-    ozo::connection_pool_timeouts timeouts;
-    timeouts.connect = std::chrono::seconds(10);
-    timeouts.queue = std::chrono::seconds(10);
-    const auto connector = ozo::make_connector(connection_pool, ioc, timeouts);
+    auto connector = make_ozo_connector(ioc);
 
     boost::asio::spawn(ioc, [&ioc, &address, &ctx, &connector,
                              &logger](boost::asio::yield_context yield) {
@@ -151,6 +132,7 @@ int main(int argc, char *argv[]) {
                                               << " | " << ozo::get_error_context(conn);
             return;
         }
+        BOOST_LOG_SEV(logger, sev::info) << "All users logged out." << port;
 
         // Open the acceptor
         tcp::acceptor acceptor(ioc);
@@ -169,6 +151,8 @@ int main(int argc, char *argv[]) {
         // Start listening for connections
         acceptor.listen(boost::asio::socket_base::max_listen_connections);
 
+        BOOST_LOG_SEV(logger, sev::info) << "Listening for connection on " << port;
+
         for (;;) {
             tcp::socket socket(ioc);
             acceptor.async_accept(socket, yield);
@@ -182,6 +166,7 @@ int main(int argc, char *argv[]) {
         }
     });
 
+    BOOST_LOG_SEV(logger, sev::info) << "Main thread ioc running.";
     ioc.run();
 
     return EXIT_SUCCESS;

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char *argv[]) {
 
     // This holds the self-signed certificate used by the server
     load_server_certificate(ctx);
-    auto connector = make_ozo_connector(ioc);
+    const auto connector = make_ozo_connector(ioc);
 
     boost::asio::spawn(ioc, [&ioc, &address, &ctx, &connector,
                              &logger](boost::asio::yield_context yield) {


### PR DESCRIPTION
make_ozo_connector returns the connector
static connection_info so the references in connector would
still work after return