### PR TITLE
boost 1.70, player to player messaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@ add_compile_definitions(BOOST_HANA_CONFIG_ENABLE_STRING_UDL)
 # TODO: enable only for debug builds
 add_compile_definitions(DELAYFACTOR=0.1)
 
-find_package(Boost 1.68.0 REQUIRED COMPONENTS system context coroutine log regex)
+SET(Boost_USE_STATIC_LIBS ON)
+find_package(Boost 1.70.0 REQUIRED COMPONENTS system context coroutine log log_setup regex)
 find_package(nlohmann_json 3.3.0 REQUIRED)
 find_package(OpenSSL 1.1.0 REQUIRED)
 find_package(Threads REQUIRED)
@@ -51,6 +52,7 @@ set(LINK_LIBS
     Boost::context
     Boost::coroutine
     Boost::log
+    Boost::log_setup
     Boost::regex
     Threads::Threads
     nlohmann_json::nlohmann_json)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ### Build
 
 see CMakeList.txt
-Boost 1.68.0, OpenSSL, nlohmann_json(https://github.com/nlohmann/json)
-ozo(submoduled)
+Boost 1.70.0, OpenSSL, nlohmann_json(https://github.com/nlohmann/json) ozo(submoduled)
+
 `./rebuild.sh`
 
 
@@ -11,7 +11,7 @@ ozo(submoduled)
 ```
 cd build
 ./niba-server /path/to/config # or just ./niba-server
-./niba-client ../testscript # or just ./niba-client or cat ../testscript - | ./niba-client
+cat ../testscript - | ./niba-client # or just ./niba-client
 ```
 
 

--- a/client/client_processor.cpp
+++ b/client/client_processor.cpp
@@ -38,6 +38,7 @@ void nibaclient::client_processor::process(nibashared::message_getdata &req) {
     if (req.success) {
         nibashared::staticdata::init(std::move(req.characters), std::move(req.magics),
                                      std::move(req.equips), std::move(req.maps));
+        std::cout << "data initialized" << std::endl;
     } else {
         std::cout << "unable to fetch gamedata" << std::endl;
         // probably should crash
@@ -105,8 +106,7 @@ void nibaclient::client_processor::process(nibashared::message_reordermagic &req
 }
 
 void nibaclient::client_processor::process(nibashared::message_echo& msg) {
-    // here is the problem, writing the iostream while reading an input could be weird
-    std::cout << msg.echo_str << std::endl;
+    std::cout << msg.sender << ": " << msg.echo_str << std::endl;
 }
 
 void nibaclient::client_processor::process(nibashared::message_send& req) {

--- a/client/client_processor.cpp
+++ b/client/client_processor.cpp
@@ -9,7 +9,7 @@
 
 using namespace nibaclient;
 
-void client_processor::process(nibashared::message_register &req) {
+void client_processor::operator()(nibashared::message_register &req) {
     if (req.success) {
         std::cout << "success" << std::endl;
     } else {
@@ -17,7 +17,7 @@ void client_processor::process(nibashared::message_register &req) {
     }
 }
 
-void client_processor::process(nibashared::message_login &req) {
+void client_processor::operator()(nibashared::message_login &req) {
     if (req.success) {
         std::cout << "success" << std::endl;
         session_.userid = req.id;
@@ -34,7 +34,7 @@ void client_processor::process(nibashared::message_login &req) {
     }
 }
 
-void nibaclient::client_processor::process(nibashared::message_getdata &req) {
+void nibaclient::client_processor::operator()(nibashared::message_getdata &req) {
     if (req.success) {
         nibashared::staticdata::init(std::move(req.characters), std::move(req.magics),
                                      std::move(req.equips), std::move(req.maps));
@@ -44,7 +44,7 @@ void nibaclient::client_processor::process(nibashared::message_getdata &req) {
     }
 }
 
-void nibaclient::client_processor::process(nibashared::message_fight &req) {
+void nibaclient::client_processor::operator()(nibashared::message_fight &req) {
     nibashared::rng_client rng(std::move(req.generated));
     auto [self_fightable, enemy_fightable] = nibashared::prep_fight(session_, req.enemyid);
     auto max_hp = static_cast<double>(self_fightable.at(0).char_data.stats.hp);
@@ -55,7 +55,7 @@ void nibaclient::client_processor::process(nibashared::message_fight &req) {
                                                       fight.elapsed_ticks());
 }
 
-void nibaclient::client_processor::process(nibashared::message_createchar &req) {
+void nibaclient::client_processor::operator()(nibashared::message_createchar &req) {
     if (req.success) {
         std::cout << "success" << std::endl;
         std::cout << req.player << std::endl;
@@ -67,7 +67,7 @@ void nibaclient::client_processor::process(nibashared::message_createchar &req) 
     }
 }
 
-void nibaclient::client_processor::process(nibashared::message_learnmagic &req) {
+void nibaclient::client_processor::operator()(nibashared::message_learnmagic &req) {
     if (req.success) {
         std::cout << "learned magic " << req.magic.name << std::endl;
         session_.data.magics.push_back(std::move(req.magic));
@@ -76,7 +76,7 @@ void nibaclient::client_processor::process(nibashared::message_learnmagic &req) 
     }
 }
 
-void nibaclient::client_processor::process(nibashared::message_fusemagic &req) {
+void nibaclient::client_processor::operator()(nibashared::message_fusemagic &req) {
     if (req.success) {
         // remove secondary magic and update primary magic
         nibautil::vector_remove(session_.data.magics, [&req](auto &magic) {
@@ -96,7 +96,7 @@ void nibaclient::client_processor::process(nibashared::message_fusemagic &req) {
     }
 }
 
-void nibaclient::client_processor::process(nibashared::message_reordermagic &req) {
+void nibaclient::client_processor::operator()(nibashared::message_reordermagic &req) {
     if (req.success) {
         session_.data.equipped_magic_ids = std::move(req.equipped_magic_ids);
     } else {

--- a/client/client_processor.cpp
+++ b/client/client_processor.cpp
@@ -9,7 +9,7 @@
 
 using namespace nibaclient;
 
-void client_processor::operator()(nibashared::message_registration &req) {
+void client_processor::process(nibashared::message_registration &req) {
     if (req.success) {
         std::cout << "success" << std::endl;
     } else {
@@ -17,7 +17,7 @@ void client_processor::operator()(nibashared::message_registration &req) {
     }
 }
 
-void client_processor::operator()(nibashared::message_login &req) {
+void client_processor::process(nibashared::message_login &req) {
     if (req.success) {
         std::cout << "success" << std::endl;
         session_.userid = req.id;
@@ -34,7 +34,7 @@ void client_processor::operator()(nibashared::message_login &req) {
     }
 }
 
-void nibaclient::client_processor::operator()(nibashared::message_getdata &req) {
+void nibaclient::client_processor::process(nibashared::message_getdata &req) {
     if (req.success) {
         nibashared::staticdata::init(std::move(req.characters), std::move(req.magics),
                                      std::move(req.equips), std::move(req.maps));
@@ -44,7 +44,7 @@ void nibaclient::client_processor::operator()(nibashared::message_getdata &req) 
     }
 }
 
-void nibaclient::client_processor::operator()(nibashared::message_fight &req) {
+void nibaclient::client_processor::process(nibashared::message_fight &req) {
     nibashared::rng_client rng(std::move(req.generated));
     auto [self_fightable, enemy_fightable] = nibashared::prep_fight(session_, req.enemyid);
     auto max_hp = static_cast<double>(self_fightable.at(0).char_data.stats.hp);
@@ -55,7 +55,7 @@ void nibaclient::client_processor::operator()(nibashared::message_fight &req) {
                                                       fight.elapsed_ticks());
 }
 
-void nibaclient::client_processor::operator()(nibashared::message_createchar &req) {
+void nibaclient::client_processor::process(nibashared::message_createchar &req) {
     if (req.success) {
         std::cout << "success" << std::endl;
         std::cout << req.player << std::endl;
@@ -67,7 +67,7 @@ void nibaclient::client_processor::operator()(nibashared::message_createchar &re
     }
 }
 
-void nibaclient::client_processor::operator()(nibashared::message_learnmagic &req) {
+void nibaclient::client_processor::process(nibashared::message_learnmagic &req) {
     if (req.success) {
         std::cout << "learned magic " << req.magic.name << std::endl;
         session_.data.magics.push_back(std::move(req.magic));
@@ -76,7 +76,7 @@ void nibaclient::client_processor::operator()(nibashared::message_learnmagic &re
     }
 }
 
-void nibaclient::client_processor::operator()(nibashared::message_fusemagic &req) {
+void nibaclient::client_processor::process(nibashared::message_fusemagic &req) {
     if (req.success) {
         // remove secondary magic and update primary magic
         nibautil::vector_remove(session_.data.magics, [&req](auto &magic) {
@@ -96,11 +96,24 @@ void nibaclient::client_processor::operator()(nibashared::message_fusemagic &req
     }
 }
 
-void nibaclient::client_processor::operator()(nibashared::message_reordermagic &req) {
+void nibaclient::client_processor::process(nibashared::message_reordermagic &req) {
     if (req.success) {
         session_.data.equipped_magic_ids = std::move(req.equipped_magic_ids);
     } else {
         std::cout << "failed to reorder magic" << std::endl;
+    }
+}
+
+void nibaclient::client_processor::process(nibashared::message_echo& msg) {
+    // here is the problem, writing the iostream while reading an input could be weird
+    std::cout << msg.echo_str << std::endl;
+}
+
+void nibaclient::client_processor::process(nibashared::message_send& req) {
+    if (req.success) {
+        std::cout << "message sent\n";
+    } else {
+        std::cout << "player offline or does not exist\n";
     }
 }
 

--- a/client/client_processor.cpp
+++ b/client/client_processor.cpp
@@ -9,7 +9,7 @@
 
 using namespace nibaclient;
 
-void client_processor::operator()(nibashared::message_register &req) {
+void client_processor::operator()(nibashared::message_registration &req) {
     if (req.success) {
         std::cout << "success" << std::endl;
     } else {

--- a/client/client_processor.h
+++ b/client/client_processor.h
@@ -25,14 +25,10 @@ public:
 
     template<typename Message, typename = nibashared::IsMessage<Message>>
     void process_response(Message &m, const nlohmann::json &merge_j) {
-        try {
-            m.base_merge_response(merge_j);
-            session_.current_time = std::chrono::high_resolution_clock::now();
-            session_.earliest_time = session_.current_time;
-            process(m);
-        } catch (std::exception &e) {
-            std::cout << "Failed to process response: " << e.what() << std::endl;
-        }
+        m.base_merge_response(merge_j);
+        session_.current_time = std::chrono::high_resolution_clock::now();
+        session_.earliest_time = session_.current_time;
+        process(m);
     }
 
 private:

--- a/client/client_processor.h
+++ b/client/client_processor.h
@@ -11,14 +11,14 @@ class client_processor {
 public:
     client_processor() = default;
     ~client_processor() = default;
-    void process(nibashared::message_register &req);
-    void process(nibashared::message_login &req);
-    void process(nibashared::message_getdata &req);
-    void process(nibashared::message_fight &req);
-    void process(nibashared::message_createchar &req);
-    void process(nibashared::message_learnmagic &req);
-    void process(nibashared::message_fusemagic &req);
-    void process(nibashared::message_reordermagic &req);
+    void operator()(nibashared::message_register &req);
+    void operator()(nibashared::message_login &req);
+    void operator()(nibashared::message_getdata &req);
+    void operator()(nibashared::message_fight &req);
+    void operator()(nibashared::message_createchar &req);
+    void operator()(nibashared::message_learnmagic &req);
+    void operator()(nibashared::message_fusemagic &req);
+    void operator()(nibashared::message_reordermagic &req);
     const nibashared::sessionstate &get_session() const;
 
     template<typename Message, typename = nibashared::IsMessage<Message>>
@@ -33,7 +33,7 @@ public:
             m.base_merge_response(merge_j);
             session_.current_time = std::chrono::high_resolution_clock::now();
             session_.earliest_time = session_.current_time;
-            process(m);
+            operator()(m);
         } catch (std::exception &e) {
             std::cout << "Client server communication failed: " << e.what() << std::endl;
         }

--- a/client/client_processor.h
+++ b/client/client_processor.h
@@ -11,14 +11,16 @@ class client_processor {
 public:
     client_processor() = default;
     ~client_processor() = default;
-    void operator()(nibashared::message_registration &req);
-    void operator()(nibashared::message_login &req);
-    void operator()(nibashared::message_getdata &req);
-    void operator()(nibashared::message_fight &req);
-    void operator()(nibashared::message_createchar &req);
-    void operator()(nibashared::message_learnmagic &req);
-    void operator()(nibashared::message_fusemagic &req);
-    void operator()(nibashared::message_reordermagic &req);
+    void process(nibashared::message_registration &req);
+    void process(nibashared::message_login &req);
+    void process(nibashared::message_getdata &req);
+    void process(nibashared::message_fight &req);
+    void process(nibashared::message_createchar &req);
+    void process(nibashared::message_learnmagic &req);
+    void process(nibashared::message_fusemagic &req);
+    void process(nibashared::message_reordermagic &req);
+    void process(nibashared::message_echo& msg);            // This is a message
+    void process(nibashared::message_send& req);            // Not handling
     const nibashared::sessionstate &get_session() const;
 
     template<typename Message, typename = nibashared::IsMessage<Message>>
@@ -27,7 +29,7 @@ public:
             m.base_merge_response(merge_j);
             session_.current_time = std::chrono::high_resolution_clock::now();
             session_.earliest_time = session_.current_time;
-            operator()(m);
+            process(m);
         } catch (std::exception &e) {
             std::cout << "Failed to process response: " << e.what() << std::endl;
         }

--- a/client/client_processor.h
+++ b/client/client_processor.h
@@ -11,7 +11,7 @@ class client_processor {
 public:
     client_processor() = default;
     ~client_processor() = default;
-    void operator()(nibashared::message_register &req);
+    void operator()(nibashared::message_registration &req);
     void operator()(nibashared::message_login &req);
     void operator()(nibashared::message_getdata &req);
     void operator()(nibashared::message_fight &req);
@@ -22,20 +22,14 @@ public:
     const nibashared::sessionstate &get_session() const;
 
     template<typename Message, typename = nibashared::IsMessage<Message>>
-    void dispatch(Message &m, const std::string &merger) {
-        std::cout << merger << std::endl;
+    void process_response(Message &m, const nlohmann::json &merge_j) {
         try {
-            auto merge_j = nlohmann::json::parse(merger);
-            if (merge_j.find("error") != merge_j.end()) {
-                std::string err = merge_j["error"].get<std::string>();
-                throw std::runtime_error(err.c_str());
-            }
             m.base_merge_response(merge_j);
             session_.current_time = std::chrono::high_resolution_clock::now();
             session_.earliest_time = session_.current_time;
             operator()(m);
         } catch (std::exception &e) {
-            std::cout << "Client server communication failed: " << e.what() << std::endl;
+            std::cout << "Failed to process response: " << e.what() << std::endl;
         }
     }
 

--- a/client/client_session.cpp
+++ b/client/client_session.cpp
@@ -78,7 +78,8 @@ void nibaclient::client_session::start() {
                 }
             } catch (std::exception &ex) {
                 std::cout << "fatal error: " << ex.what() << "\n";
-                throw ex;
+                // throw ex;
+                break;
             }
         }
     });

--- a/client/client_session.cpp
+++ b/client/client_session.cpp
@@ -8,58 +8,98 @@ namespace websocket = beast::websocket; // from <boost/beast/websocket.hpp>
 
 using namespace nibaclient;
 
-namespace {
-
-// auto set a void promise on destruction
-struct promise_setter {
-public:
-    promise_setter(std::promise<void>& promise): promise_(promise) {}
-    ~promise_setter() {
-        promise_.set_value();
-    }
-private:
-    std::promise<void>& promise_;
-};
-
-}
-
-// , work_(ioc_)
 nibaclient::client_session::client_session(std::string const &host, std::string const &port,
                                            boost::asio::io_context &ioc, ssl::context &ssl_ctx) :
-    host_(host),
-    port_(port), ioc_(ioc), resolver_(ioc_), ws_(ioc_, ssl_ctx) {
-    // TODO make all async
-    // everything can be sync because this client has no ui anyway
-    auto const results = resolver_.resolve(host_, port_);
-    beast::get_lowest_layer(ws_).expires_after(std::chrono::seconds(30));
-    beast::get_lowest_layer(ws_).connect(results);
-    boost::asio::ip::tcp::no_delay option(true);
-    beast::get_lowest_layer(ws_).socket().set_option(option);
-    beast::get_lowest_layer(ws_).expires_after(std::chrono::seconds(30));
-    ws_.next_layer().handshake(ssl::stream_base::client);
-    beast::get_lowest_layer(ws_).expires_never();
-    ws_.set_option(websocket::stream_base::timeout::suggested(beast::role_type::client));    
-    ws_.handshake(host_, "/");
+    host_{host},
+    port_{port}, ioc_{ioc}, resolver_{ioc_}, ws_{ioc_, ssl_ctx}, ready_promise_{},
+    ready_future_{ready_promise_.get_future()} {}
+
+void nibaclient::client_session::start() {
+    // Note we only have 1 ioc_ thread, so no strand needed
+    boost::asio::spawn(ioc_, [this, self = shared_from_this()](boost::asio::yield_context yield) {
+        try {
+            auto const results = resolver_.async_resolve(host_, port_, yield);
+            beast::get_lowest_layer(ws_).expires_after(std::chrono::seconds(30));
+            beast::get_lowest_layer(ws_).async_connect(results, yield);
+            boost::asio::ip::tcp::no_delay option(true);
+            beast::get_lowest_layer(ws_).socket().set_option(option);
+            beast::get_lowest_layer(ws_).expires_after(std::chrono::seconds(30));
+            ws_.next_layer().async_handshake(ssl::stream_base::client, yield);
+            beast::get_lowest_layer(ws_).expires_never();
+            ws_.set_option(websocket::stream_base::timeout::suggested(beast::role_type::client));
+            ws_.async_handshake(host_, "/", yield);
+            ready_promise_.set_value();
+        } catch (...) {
+            // Apparently this can throw as well, but let's see if we care...
+            ready_promise_.set_exception(std::current_exception());
+            return;
+        }
+        // Now start long running read coroutine
+        for(;;) {
+            std::string incoming_str;
+            auto buffer = boost::asio::dynamic_buffer(incoming_str);
+            try {
+                ws_.async_read(buffer, yield);
+                std::cerr << request_stopwatch_.elapsed_ms() << std::endl;
+                std::cout << incoming_str << "\n";
+                auto json = nlohmann::json::parse(incoming_str);
+                if (json.find("error") != json.end()) {
+                    std::string err = json["error"].get<std::string>();
+                    throw std::runtime_error(err.c_str());
+                }
+                nibashared::message::tag tag{json.at("tag").get<int>()};
+                if (request_.has_value() && tag == nibashared::message::tag::response) {
+                    // Since we strictly wait for 1 response per request, this response must match the request.
+                    // Merge it with the request and process.
+                    std::visit([&json, this, yield](auto& response) {
+                        processor_.process_response(response, json);
+                        // Manually chain the getdata message
+                        if (response.type == nibashared::message::type::login) {
+                            write_message(nibashared::message_getdata{}, yield);
+                        } else {
+                            // Set the promise!
+                            std::cout << "DEBUG setting promise for response\n";
+                            request_promise_.set_value(response.type);
+                        }
+                    }, request_.value());
+                } else {
+                    // It's some unknown message, just process it
+                    nibashared::message::dispatcher(json, [this](auto message){
+                        // Incoming message, assume "it just works"
+                        processor_(message);
+                    });
+                }
+            } catch (std::exception& ex) {
+                std::cout << "failed to process incoming message: " << ex.what() << "\n";
+                break;
+            }
+        }
+
+        // processor_.dispatch(message, response_str);
+    });
 }
 
-nibaclient::client_session::~client_session() { close(); }
+void nibaclient::client_session::block_until_ready() { ready_future_.get(); }
 
-void nibaclient::client_session::close() {
+void nibaclient::client_session::stop() {
+    // Exceptions may happen in the destructor, but if it throws, then let it crash...?
     if (ws_.is_open()) {
-        beast::get_lowest_layer(ws_).cancel();
-        ws_.close(websocket::close_code::normal);
+        // ioc should finish the close before shutting down
+        ws_.async_close(websocket::close_code::normal, [](beast::error_code ec) {
+            std::cout << ec.message() << std::endl;
+        });
     }
 }
 
-void nibaclient::client_session::handle_cmd(const std::string &input, std::promise<void>&& promise) {
-    promise_setter set_promise(promise);
+std::future<nibashared::message::type>
+nibaclient::client_session::handle_cmd(const std::string &input) {
     try {
         handled_ = true;
         std::vector<std::string> results;
         boost::split(results, input, boost::is_any_of("\t "));
         if (results.empty())
             throw std::runtime_error("empty input");
-        // dynamic sized
+        // Dynamically sized arguments
         if (results[0] == "reordermagic") {
             std::vector<int> selected;
             std::for_each(results.begin() + 1, results.end(),
@@ -68,13 +108,13 @@ void nibaclient::client_session::handle_cmd(const std::string &input, std::promi
         }
         if (results.size() == 3) {
             if (results[0] == "register") {
-                return create_and_go<nibashared::message_register>(std::move(results[1]),
+                return create_and_go<nibashared::message_registration>(std::move(results[1]),
                                                                    std::move(results[2]));
             } else if (results[0] == "login") {
-                create_and_go<nibashared::message_login>(std::move(results[1]),
-                                                         std::move(results[2]));
-                // force a getdata after login
-                return create_and_go<nibashared::message_getdata>();
+                return create_and_go<nibashared::message_login>(std::move(results[1]),
+                                                                std::move(results[2]));
+                // Force a getdata after login
+                // create_and_go<nibashared::message_getdata>();
             } else if (results[0] == "fusemagic") {
                 return create_and_go<nibashared::message_fusemagic>(std::stoi(results[1]),
                                                                     std::stoi(results[2]));
@@ -85,8 +125,8 @@ void nibaclient::client_session::handle_cmd(const std::string &input, std::promi
             } else if (results[0] == "learnmagic") {
                 return create_and_go<nibashared::message_learnmagic>(std::stoi(results[1]));
             } else if (results[0] == "timeout") {
+                // This should be posted to ioc, TODO
                 std::this_thread::sleep_for(std::chrono::seconds(std::stoi(results[1])));
-                return;
             }
         } else if (results.size() == 7) {
             if (results[0] == "create") {
@@ -98,18 +138,24 @@ void nibaclient::client_session::handle_cmd(const std::string &input, std::promi
                                                  .physique = std::stoi(results[5]),
                                                  .spirit = std::stoi(results[6])}});
             }
+        } else {
+            throw std::runtime_error("incorrect command");
         }
-    } catch (...) {
-        std::cout << "incorrect command" << std::endl;
-        // parsing failure whatever
+    } catch (std::exception &exc) {
+        std::cout << exc.what() << std::endl;
     }
     handled_ = false;
+    // Return a dummy future, that has promised already fulfilled
+    std::promise<nibashared::message::type> promise;
+    auto future = promise.get_future();
+    promise.set_value(nibashared::message::type::none);
+    return future;
 }
 
 std::chrono::high_resolution_clock::time_point nibaclient::client_session::earliest() const {
     if (!handled_)
         return {};
-    // if no change then it means do whatever
+    // If no change then it means do whatever
     if (processor_.get_session().earliest_time == processor_.get_session().current_time)
         return {};
     return processor_.get_session().earliest_time;

--- a/client/client_session.h
+++ b/client/client_session.h
@@ -13,6 +13,9 @@
 #include <boost/beast/websocket.hpp>
 #include <boost/beast/websocket/ssl.hpp>
 
+#include <optional>
+#include <future>
+
 namespace nibaclient {
 
 class client_session {
@@ -21,7 +24,7 @@ public:
                    boost::asio::ssl::context &ssl_ctx);
     ~client_session();
 
-    void handle_cmd(const std::string &input);
+    void handle_cmd(const std::string &input, std::promise<void>&& promise);
     std::chrono::high_resolution_clock::time_point earliest() const;
 
 private:
@@ -51,6 +54,7 @@ private:
     boost::asio::ip::tcp::resolver resolver_;
     boost::beast::websocket::stream<boost::beast::ssl_stream<boost::beast::tcp_stream>> ws_;
     client_processor processor_;
+    std::optional<nibashared::variant_message> request_;
     bool handled_ = false;
 };
 

--- a/client/client_session.h
+++ b/client/client_session.h
@@ -7,54 +7,83 @@
 #include "util.h"
 
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/spawn.hpp>
 #include <boost/asio/ssl/stream.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/ssl.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/beast/websocket/ssl.hpp>
 
-#include <optional>
 #include <future>
+#include <memory>
+#include <optional>
 
 namespace nibaclient {
 
-class client_session {
+class client_session : public std::enable_shared_from_this<client_session> {
 public:
     client_session(std::string const &host, std::string const &port, boost::asio::io_context &ioc,
                    boost::asio::ssl::context &ssl_ctx);
-    ~client_session();
-
-    void handle_cmd(const std::string &input, std::promise<void>&& promise);
+    void start(); // unfortunately we need this as shared_from_this() wouldn't work in constructor
+    void block_until_ready();
+    void stop();
+    std::future<nibashared::message::type> handle_cmd(const std::string &input);
     std::chrono::high_resolution_clock::time_point earliest() const;
 
 private:
     template<typename Message, typename... Args, typename = nibashared::IsMessage<Message>>
-    void create_and_go(Args &&... args) {
+    std::future<nibashared::message::type> create_and_go(Args &&... args) {
+        // User will not overwrite a non-fulfilled promise as they'd have
+        request_promise_ = std::promise<nibashared::message::type>();
+        auto future = request_promise_.get_future();
         Message message(std::forward<Args>(args)...);
-        if (!message.base_validate(processor_.get_session())) {
-            // TODO maybe message specific error msg
-            std::cout << "command validation failed" << std::endl;
-        } else {
-            auto request_json = message.base_create_request();
-            std::string request_str = request_json.dump();
-            nibautil::stopwatch stopwatch;
-            ws_.write(boost::asio::buffer(request_str));
-            std::string response_str;
-            auto buffer = boost::asio::dynamic_buffer(response_str);
-            ws_.read(buffer);
-            std::cerr << stopwatch.elapsed_ms() << std::endl;
-            processor_.dispatch(message, response_str);
+        std::cout << "DEBUG spawning coroutine to handle request\n";
+        // Post to ioc thread(or spawn coroutine) to avoid accessing data on 2 threads
+        // particularly, request_ should be shielded
+        boost::asio::spawn(ioc_, [this, self = shared_from_this(),
+                                  message{std::move(message)}](boost::asio::yield_context yield) mutable {
+            if (!message.base_validate(processor_.get_session())) {
+                // TODO maybe message specific error msg
+                std::cout << "command validation failed" << std::endl;
+                request_promise_.set_value(nibashared::message::type::none);
+            } else {
+                write_message(std::move(message), yield);
+            }
+        });
+        return future;
+    }
+
+    template<typename Message>
+    void write_message(Message&& message, boost::asio::yield_context yield) {
+        auto request_json = message.base_create_request();
+        std::string request_str = request_json.dump();
+        std::cout << "DEBUG " << request_str << "\n";
+        request_.emplace(std::move(message));
+        request_stopwatch_.reset();
+        boost::system::error_code ec;
+        ws_.async_write(boost::asio::buffer(request_str), yield[ec]);
+        if (ec) {
+            // TODO figure out how to handle error properly
+            std::cout << "failed to write data " << ec.message() << std::endl;
+            request_promise_.set_value(nibashared::message::type::none);
+            request_.reset();
         }
     }
-    void close();
 
     std::string const &host_;
     std::string const &port_;
     boost::asio::io_context &ioc_;
     boost::asio::ip::tcp::resolver resolver_;
     boost::beast::websocket::stream<boost::beast::ssl_stream<boost::beast::tcp_stream>> ws_;
+    std::promise<void> ready_promise_;
+    std::future<void> ready_future_;
+
     client_processor processor_;
-    std::optional<nibashared::variant_message> request_;
+
+    std::optional<nibashared::message::variant> request_;
+    std::promise<nibashared::message::type> request_promise_;
+    nibautil::stopwatch request_stopwatch_;
+
     bool handled_ = false;
 };
 

--- a/client/client_session.h
+++ b/client/client_session.h
@@ -6,12 +6,10 @@
 #include "structs.h"
 #include "util.h"
 
-#include <boost/algorithm/string.hpp>
-#include <boost/asio/connect.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl/stream.hpp>
-#include <boost/asio/steady_timer.hpp>
 #include <boost/beast/core.hpp>
+#include <boost/beast/ssl.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/beast/websocket/ssl.hpp>
 
@@ -46,14 +44,12 @@ private:
         }
     }
     void close();
-    void ping_timer(boost::system::error_code ec);
 
     std::string const &host_;
     std::string const &port_;
     boost::asio::io_context &ioc_;
     boost::asio::ip::tcp::resolver resolver_;
-    boost::beast::websocket::stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>> ws_;
-    boost::asio::steady_timer timer_;
+    boost::beast::websocket::stream<boost::beast::ssl_stream<boost::beast::tcp_stream>> ws_;
     client_processor processor_;
     bool handled_ = false;
 };

--- a/client/client_session.h
+++ b/client/client_session.h
@@ -37,7 +37,6 @@ private:
         request_promise_ = std::promise<nibashared::message::type>();
         auto future = request_promise_.get_future();
         Message message(std::forward<Args>(args)...);
-        std::cout << "DEBUG spawning coroutine to handle request\n";
         // Post to ioc thread(or spawn coroutine) to avoid accessing data on 2 threads
         // particularly, request_ should be shielded
         boost::asio::spawn(ioc_, [this, self = shared_from_this(),
@@ -57,7 +56,6 @@ private:
     void write_message(Message&& message, boost::asio::yield_context yield) {
         auto request_json = message.base_create_request();
         std::string request_str = request_json.dump();
-        std::cout << "DEBUG " << request_str << "\n";
         request_.emplace(std::move(message));
         request_stopwatch_.reset();
         boost::system::error_code ec;

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -50,12 +50,13 @@ int main(int argc, char **argv) {
     std::thread io_worker([&ioc] { ioc.run(); });
 
     auto session_ptr = std::make_shared<nibaclient::client_session>(host, port, ioc, ctx);
-    // This needs to be shared_ptr to use shared_from_this(), which makes our coroutines
-    // safe to access all members at all times, which is unfortunate as we can't rely
-    // on constructor and destructor for initialization and cleanup.
+    // This needs to be a shared_ptr to use shared_from_this(), which makes our coroutine
+    // safe to access all members at all times. 
+    // We can't rely on destructor for cleanup as a long running coroutine might not be done yet.
     // Another way would be that the destructor should wait for futures that the coroutine
     // would set at the end its execution.
     session_ptr->start();
+    // Use start so we can fetch the first line of input while being setup
 
     std::string line{};
 

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -80,8 +80,8 @@ int main(int argc, char **argv) {
   
         std::getline(instream, line);
 
-        std::cout << "waiting for future\n";
         // Blocks until request is completed, we may need better ways to handle it
+        // TODO try catch, 2 types of exception: ignore, terminate
         future.wait();
     }
     // Need to stop() the session so async_read would error out and eventually stop all

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -10,7 +10,7 @@
 
 #include <chrono>
 #include <condition_variable>
-#include <fstream>
+// #include <fstream>
 #include <future>
 #include <iostream>
 #include <memory>
@@ -28,14 +28,23 @@ namespace ssl = boost::asio::ssl;              // from <boost/asio/ssl.hpp>
 namespace websocket = boost::beast::websocket; // from <boost/beast/websocket.hpp>
 
 int main(int argc, char **argv) {
-    std::unique_ptr<std::ifstream> fin{};
-    if (argc == 2) {
-        fin = std::make_unique<std::ifstream>(argv[1]);
-    }
-    std::istream &instream = fin ? *fin : std::cin;
+    // std::unique_ptr<std::ifstream> fin{};
+    // if (argc == 2) {
+    //     fin = std::make_unique<std::ifstream>(argv[1]);
+    // }
+    // std::istream &instream = fin ? *fin : std::cin;
+
+    // disable fstream in for now
+    std::istream &instream = std::cin;
 
     std::string host{"localhost"};
     std::string port{"19999"};
+    if (argc >= 2) {
+        host = argv[1];
+    }
+    if (argc == 3) {
+        port = argv[2];
+    }
 
     // The SSL context is required, and holds certificates
     ssl::context ctx{ssl::context::sslv23_client};
@@ -51,7 +60,7 @@ int main(int argc, char **argv) {
 
     auto session_ptr = std::make_shared<nibaclient::client_session>(host, port, ioc, ctx);
     // This needs to be a shared_ptr to use shared_from_this(), which makes our coroutine
-    // safe to access all members at all times. 
+    // safe to access all members at all times.
     // We can't rely on destructor for cleanup as a long running coroutine might not be done yet.
     // Another way would be that the destructor should wait for futures that the coroutine
     // would set at the end its execution.
@@ -76,9 +85,9 @@ int main(int argc, char **argv) {
             std::cout << "cooldown " << delay.count() << "ns" << std::endl;
             std::this_thread::sleep_for(delay);
         }
-        
+
         auto future = session_ptr->handle_cmd(line);
-  
+
         std::getline(instream, line);
 
         // Blocks until request is completed, we may need better ways to handle it

--- a/server/config.h
+++ b/server/config.h
@@ -10,7 +10,7 @@ namespace nibaserver {
 struct config {
     std::string host;
     unsigned short port;
-    std::size_t threads;
+    int threads;
     std::string static_conn_str;
     std::string player_conn_str;
 };
@@ -18,7 +18,7 @@ struct config {
 inline config read_config(int argc, char *argv[]) {
     config my_config = {.host = "0.0.0.0",
                         .port = 19999,
-                        .threads = 1,
+                        .threads = 2,
                         .static_conn_str = "dbname=niba_static user=postgres",
                         .player_conn_str = "dbname=niba user=postgres"};
     if (argc < 2) {
@@ -33,10 +33,9 @@ inline config read_config(int argc, char *argv[]) {
         if (auto iter = json.find("port"); iter != json.end()) {
             iter->get_to(my_config.port);
         }
-        // to be supported
-        // if (auto iter = json.find("threads"); iter != json.end()) {
-        //     iter->get_to(my_config.threads);
-        // }
+        if (auto iter = json.find("threads"); iter != json.end()) {
+            iter->get_to(my_config.threads);
+        }
         if (auto iter = json.find("static_conn_str"); iter != json.end()) {
             iter->get_to(my_config.static_conn_str);
         }

--- a/server/connector.h
+++ b/server/connector.h
@@ -3,7 +3,8 @@
 #include <ozo/connection.h>
 #include <ozo/connection_info.h>
 #include <ozo/connection_pool.h>
-#include <structs.h>
+
+#include "structs.h"
 
 OZO_PG_DEFINE_CUSTOM_TYPE(nibashared::attributes, "character_four_attributes")
 OZO_PG_DEFINE_CUSTOM_TYPE(nibashared::player, "character_info")

--- a/server/connector.h
+++ b/server/connector.h
@@ -14,24 +14,24 @@ OZO_PG_DEFINE_CUSTOM_TYPE(nibashared::magic, "magic_info")
 namespace nibaserver {
 
 // we use this just to get around needing to write out the type for the connector
-inline static auto &make_ozo_connector_pool(const std::string &player_conn_str) {
+inline auto make_ozo_connector_pool(const std::string &player_conn_str) {
     // note these are static so they still exist after we return from this function
-    static auto connection_info = ozo::make_connection_info(
+    auto connection_info = ozo::make_connection_info(
         player_conn_str, ozo::register_types<nibashared::attributes, nibashared::magic,
                                              nibashared::player, nibashared::battlestats>());
-    static ozo::connection_pool_config connection_pool_config;
+    ozo::connection_pool_config connection_pool_config;
     // Maximum limit for number of stored connections
     connection_pool_config.capacity = 10;
     // Maximum limit for number of waiting requests for connection
     connection_pool_config.queue_capacity = 500;
     // Maximum time duration to store unused open connection
     connection_pool_config.idle_timeout = std::chrono::seconds(60);
-    static auto connection_pool =
-        ozo::make_connection_pool(connection_info, connection_pool_config);
+    auto connection_pool =
+        ozo::make_connection_pool(std::move(connection_info), connection_pool_config);
     return connection_pool;
 }
 
-using niba_ozo_connection_pool_ref =
+using niba_ozo_connection_pool =
     std::invoke_result_t<decltype(&make_ozo_connector_pool), const std::string &>;
 
 } // namespace nibaserver

--- a/server/connector.h
+++ b/server/connector.h
@@ -34,15 +34,4 @@ inline static auto &make_ozo_connector_pool(const std::string &player_conn_str) 
 using niba_ozo_connection_pool_ref =
     std::invoke_result_t<decltype(&make_ozo_connector_pool), const std::string &>;
 
-inline auto make_ozo_connector(niba_ozo_connection_pool_ref &pool, boost::asio::io_context &ioc) {
-    ozo::connection_pool_timeouts timeouts;
-    timeouts.connect = std::chrono::seconds(10);
-    timeouts.queue = std::chrono::seconds(10);
-    return ozo::make_connector(pool, ioc, timeouts);
-}
-
-using niba_ozo_connector =
-    std::invoke_result_t<decltype(&make_ozo_connector), niba_ozo_connection_pool_ref &,
-                         boost::asio::io_context &>;
-
 } // namespace nibaserver

--- a/server/connector.h
+++ b/server/connector.h
@@ -21,9 +21,9 @@ inline static auto &make_ozo_connector_pool(const std::string &player_conn_str) 
                                              nibashared::player, nibashared::battlestats>());
     static ozo::connection_pool_config connection_pool_config;
     // Maximum limit for number of stored connections
-    connection_pool_config.capacity = 100;
+    connection_pool_config.capacity = 10;
     // Maximum limit for number of waiting requests for connection
-    connection_pool_config.queue_capacity = 5000;
+    connection_pool_config.queue_capacity = 500;
     // Maximum time duration to store unused open connection
     connection_pool_config.idle_timeout = std::chrono::seconds(60);
     static auto connection_pool =

--- a/server/db_accessor.cpp
+++ b/server/db_accessor.cpp
@@ -126,6 +126,9 @@ bool db_accessor::create_user(const std::string &id, const std::string &password
                              "INSERT INTO user_id (id, hashed_password, salt) VALUES ("_SQL + id +
                                  ","_SQL + pswd_bytea + ","_SQL + salt_bytea + ")"_SQL,
                              ozo::deadline(default_timeout), yield[ec]);
+    if (ec == ozo::sqlstate::make_error_code(ozo::sqlstate::unique_violation)) {
+        return false;
+    }
     CHECKDBERROR(ec, conn, false);
 
     return true;
@@ -181,8 +184,9 @@ bool db_accessor::create_char(const std::string &id, const nibashared::player &p
                              "INSERT INTO player_character(id, character) VALUES("_SQL + id +
                                  ","_SQL + player + ")"_SQL,
                              ozo::deadline(default_timeout), yield[ec]);
-
-    // might not be an error
+    if (ec == ozo::sqlstate::make_error_code(ozo::sqlstate::unique_violation)) {
+        return false;
+    }
     CHECKDBERROR(ec, conn, false);
     return true;
 }

--- a/server/db_accessor.cpp
+++ b/server/db_accessor.cpp
@@ -77,7 +77,7 @@ bool db_accessor::login(const std::string &id, const std::string &password,
             return false;
         }
 
-        ozo::execute(conn_pool_[ioc_], "UPDATE user_id SET logged_in = true WHERE id="_SQL + id,
+        ozo::execute(conn, "UPDATE user_id SET logged_in = true WHERE id="_SQL + id,
                      ozo::deadline(default_timeout), yield[ec]);
         CHECKDBERROR(ec, conn, false);
         return true;
@@ -163,15 +163,14 @@ nibashared::playerdata nibaserver::db_accessor::get_aux(const std::string &name,
     }
     BOOST_LOG_SEV(logger_, sev::info) << "getting player magics " << name;
     ozo::rows_of<std::vector<int>> equipped_magic_rows;
-    conn = ozo::request(conn_pool_[ioc_],
+    conn = ozo::request(conn,
                         "SELECT magics FROM character_equipped_magic WHERE character_name = "_SQL +
                             name,
                         ozo::deadline(default_timeout), ozo::into(equipped_magic_rows), yield[ec]);
+    CHECKDBERROR(ec, conn, ret);
     if (equipped_magic_rows.size() != 0) {
         ret.equipped_magic_ids = std::get<0>(equipped_magic_rows.back());
     }
-    CHECKDBERROR(ec, conn, ret);
-
     return ret;
 }
 

--- a/server/db_accessor.h
+++ b/server/db_accessor.h
@@ -18,7 +18,7 @@ namespace nibaserver {
 
 class db_accessor {
 public:
-    db_accessor(niba_ozo_connection_pool_ref &conn_pool, boost::asio::io_context &ioc);
+    db_accessor(niba_ozo_connection_pool &conn_pool, boost::asio::io_context &ioc);
     // ~db_accessor() = default;
     bool login(const std::string &id, const std::string &password,
                boost::asio::yield_context &yield);
@@ -51,13 +51,9 @@ public:
                       boost::asio::yield_context &yield);
 
 private:
-    auto get_connector() {
-        return conn_pool_[ioc_];
-    }
-
     logger logger_;
-    niba_ozo_connection_pool_ref& conn_pool_;
-    boost::asio::io_context& ioc_;
+    niba_ozo_connection_pool &conn_pool_;
+    boost::asio::io_context &ioc_;
 };
 
 } // namespace nibaserver

--- a/server/db_accessor.h
+++ b/server/db_accessor.h
@@ -52,7 +52,7 @@ public:
 
 private:
     auto get_connector() {
-        return make_ozo_connector(conn_pool_, ioc_);
+        return conn_pool_[ioc_];
     }
 
     logger logger_;

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -110,13 +110,14 @@ int main(int argc, char *argv[]) {
     });
 
     // session_ptr clean up
+    constexpr auto interval = std::chrono::minutes(5);  // TODO: make it configurable
     boost::asio::steady_timer cleanup_timer{ioc};
-    cleanup_timer.expires_after(std::chrono::minutes(5));
+    cleanup_timer.expires_after(interval);
     boost::asio::spawn(ioc, [&cleanup_timer, &ss_map](boost::asio::yield_context yield) {
         for (;;) {
             cleanup_timer.async_wait(yield);
             ss_map.cleanup();
-            cleanup_timer.expires_after(std::chrono::minutes(3));
+            cleanup_timer.expires_after(interval);
         }
     });
 

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -80,11 +80,7 @@ int main(int argc, char *argv[]) {
         // Allow address reuse
         acceptor.set_option(boost::asio::socket_base::reuse_address(true));
         // Bind to the server address
-        acceptor.bind(endpoint, ec);
-        if (ec) {
-            BOOST_LOG_SEV(logger, sev::error) << "Binding failure: " << ec.message();
-            return;
-        }
+        acceptor.bind(endpoint);
 
         // Start listening for connections
         acceptor.listen(boost::asio::socket_base::max_listen_connections);
@@ -98,8 +94,8 @@ int main(int argc, char *argv[]) {
             socket.set_option(option);
             BOOST_LOG_SEV(logger, sev::info) << "Got connection";
             nibaserver::db_accessor db(connection_pool, ioc);
-            auto session = std::make_shared<server_session>(acceptor.get_executor().context(),
-                                                            std::move(socket), ctx, std::move(db));
+            auto session =
+                std::make_shared<server_session>(ioc, std::move(socket), ctx, std::move(db));
             session->go();
         }
     });

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -116,7 +116,7 @@ int main(int argc, char *argv[]) {
         for (;;) {
             cleanup_timer.async_wait(yield);
             ss_map.cleanup();
-            cleanup_timer.expires_after(std::chrono::minutes(5));
+            cleanup_timer.expires_after(std::chrono::minutes(3));
         }
     });
 

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[]) {
 
     // This holds the self-signed certificate used by the server
     load_server_certificate(ctx);
-    auto &connection_pool = make_ozo_connector_pool(conf.player_conn_str);
+    auto connection_pool = make_ozo_connector_pool(conf.player_conn_str);
 
     // We need a global session weakptr to handle player connections
     // and a timer to periodically cleanup the weakptr

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -1,6 +1,7 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/asio/ssl/stream.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/beast/websocket/ssl.hpp>
@@ -10,6 +11,7 @@
 #include <ozo/shortcuts.h>
 
 #include <cstdlib>
+#include <chrono>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -24,6 +26,7 @@
 #include "gamedata.h"
 #include "logger.h"
 #include "server_session.h"
+#include "session_map.h"
 
 using tcp = boost::asio::ip::tcp;              // from <boost/asio/ip/tcp.hpp>
 namespace ssl = boost::asio::ssl;              // from <boost/asio/ssl.hpp>
@@ -46,7 +49,7 @@ int main(int argc, char *argv[]) {
     BOOST_LOG_SEV(logger, sev::info) << "Game data loaded.";
 
     // The io_context is required for all I/O
-    boost::asio::io_context ioc(threads);
+    boost::asio::io_context ioc{threads};
 
     // The SSL context is required, and holds certificates
     ssl::context ctx{ssl::context::sslv23};
@@ -55,8 +58,14 @@ int main(int argc, char *argv[]) {
     load_server_certificate(ctx);
     auto &connection_pool = make_ozo_connector_pool(conf.player_conn_str);
 
+    // We need a global session weakptr to handle player connections
+    // and a timer to periodically cleanup the weakptr
+    // The key of the mapping would be the user_id
+    // the global sessions will be passed into the server_session?
+    session_map ss_map;
+
     boost::asio::spawn(ioc, [&ioc, &address, &port, &ctx, &connection_pool,
-                             &logger](boost::asio::yield_context yield) {
+                             &logger, &ss_map](boost::asio::yield_context yield) {
         using namespace ozo::literals;
         boost::system::error_code ec;
 
@@ -73,7 +82,7 @@ int main(int argc, char *argv[]) {
         BOOST_LOG_SEV(logger, sev::info) << "All users logged out.";
 
         // Open the acceptor
-        tcp::acceptor acceptor(ioc);
+        tcp::acceptor acceptor{ioc};
         tcp::endpoint endpoint{address, port};
         acceptor.open(endpoint.protocol());
 
@@ -88,17 +97,29 @@ int main(int argc, char *argv[]) {
         BOOST_LOG_SEV(logger, sev::info) << "Listening for connection on " << port;
 
         for (;;) {
-            tcp::socket socket(ioc);
+            tcp::socket socket{ioc};
             acceptor.async_accept(socket, yield);
             tcp::no_delay option(true);
             socket.set_option(option);
             BOOST_LOG_SEV(logger, sev::info) << "Got connection";
-            nibaserver::db_accessor db(connection_pool, ioc);
-            auto session =
-                std::make_shared<server_session>(ioc, std::move(socket), ctx, std::move(db));
+            nibaserver::db_accessor db{connection_pool, ioc};
+            auto session = std::make_shared<server_session>(ioc, std::move(socket), ctx,
+                                                            std::move(db), ss_map);
             session->go();
         }
     });
+
+    // session_ptr clean up
+    boost::asio::steady_timer cleanup_timer{ioc};
+    cleanup_timer.expires_after(std::chrono::minutes(5));
+    boost::asio::spawn(ioc, [&cleanup_timer, &ss_map](boost::asio::yield_context yield) {
+        for (;;) {
+            cleanup_timer.async_wait(yield);
+            ss_map.cleanup();
+            cleanup_timer.expires_after(std::chrono::minutes(5));
+        }
+    });
+
 
     BOOST_LOG_SEV(logger, sev::info) << "Main thread ioc running.";
     std::vector<std::thread> v;

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -71,8 +71,8 @@ int main(int argc, char *argv[]) {
 
         // TODO: move elsewhere
         // reset the login status on start up
-        auto connector = make_ozo_connector(connection_pool, ioc);
-        auto conn = ozo::execute(connector, "UPDATE user_id SET logged_in = false WHERE 1 = 1"_SQL,
+        auto conn = ozo::execute(connection_pool[ioc], "UPDATE user_id SET logged_in = false WHERE 1 = 1"_SQL,
+                                 ozo::deadline(std::chrono::seconds(5)),
                                  yield[ec]);
         if (ec) {
             BOOST_LOG_SEV(logger, sev::error) << ec.message() << " | " << ozo::error_message(conn)

--- a/server/server_processor.cpp
+++ b/server/server_processor.cpp
@@ -21,29 +21,29 @@ std::string server_processor::dispatch(const std::string &request) {
     try {
         auto j = nlohmann::json::parse(request);
         auto cmd_id = j.at("type").get<std::size_t>();
-        switch (static_cast<nibashared::cmdtype>(cmd_id)) {
-        case nibashared::cmdtype::registeration: {
+        switch (static_cast<nibashared::type_message>(cmd_id)) {
+        case nibashared::type_message::registeration: {
             return do_request<nibashared::message_register>(j);
         }
-        case nibashared::cmdtype::login: {
+        case nibashared::type_message::login: {
             return do_request<nibashared::message_login>(j);
         }
-        case nibashared::cmdtype::getdata: {
+        case nibashared::type_message::getdata: {
             return do_request<nibashared::message_getdata>(j);
         }
-        case nibashared::cmdtype::fight: {
+        case nibashared::type_message::fight: {
             return do_request<nibashared::message_fight>(j);
         }
-        case nibashared::cmdtype::createchar: {
+        case nibashared::type_message::createchar: {
             return do_request<nibashared::message_createchar>(j);
         }
-        case nibashared::cmdtype::learnmagic: {
+        case nibashared::type_message::learnmagic: {
             return do_request<nibashared::message_learnmagic>(j);
         }
-        case nibashared::cmdtype::fusemagic: {
+        case nibashared::type_message::fusemagic: {
             return do_request<nibashared::message_fusemagic>(j);
         }
-        case nibashared::cmdtype::reordermagic: {
+        case nibashared::type_message::reordermagic: {
             return do_request<nibashared::message_reordermagic>(j);
         }
         default:

--- a/server/server_processor.h
+++ b/server/server_processor.h
@@ -18,7 +18,7 @@ public:
     // and then finally return the serialized message
     std::string dispatch(const std::string &request);
     // process needed for all messages
-    void process(nibashared::message_register &req);
+    void process(nibashared::message_registration &req);
     void process(nibashared::message_login &req);
     void process(nibashared::message_getdata &req);
     void process(nibashared::message_fight &req);
@@ -33,23 +33,5 @@ private:
     nibashared::sessionstate session_;
     boost::asio::yield_context &yield_;
     nibaserver::db_accessor &db_;
-
-    template<typename RequestMessage, typename = nibashared::IsMessage<RequestMessage>>
-    std::string do_request(const nlohmann::json &json_request) {
-        // TODO: minimize exceptions
-        // check if past earliest_time, then reset
-        session_.current_time = std::chrono::high_resolution_clock::now();
-        if (session_.current_time < session_.earliest_time) {
-            throw std::runtime_error("request too frequent");
-        }
-        session_.earliest_time = session_.current_time;
-        RequestMessage req;
-        req.base_from_request(json_request);
-        if (!req.base_validate(session_)) {
-            throw std::runtime_error("validation failure");
-        }
-        process(req);
-        return req.base_create_response().dump();
-    }
 };
 } // namespace nibaserver

--- a/server/server_processor.h
+++ b/server/server_processor.h
@@ -3,8 +3,8 @@
 #include "global_defs.h"
 #include "logger.h"
 #include "message.h"
-#include "sessiondata.h"
 #include "session_map.h"
+#include "sessiondata.h"
 
 #include <boost/asio/spawn.hpp>
 #include <chrono>
@@ -12,10 +12,11 @@
 
 namespace nibaserver {
 class server_processor {
-using session_wptr = std::weak_ptr<server_session>;
+    using session_wptr = std::weak_ptr<server_session>;
 
 public:
-    server_processor(boost::asio::yield_context &yield, db_accessor &db, session_map& ss_map, session_wptr ss_wptr);
+    server_processor(boost::asio::yield_context &yield, db_accessor &db, session_map &ss_map,
+                     session_wptr ss_wptr);
     ~server_processor() = default;
     // dispatch is responsible to handle all the type conversion, make the whatever calls
     // and then finally return the serialized message
@@ -29,8 +30,8 @@ public:
     void process(nibashared::message_learnmagic &req);
     void process(nibashared::message_fusemagic &req);
     void process(nibashared::message_reordermagic &req);
-    void process(nibashared::message_echo& req);
-    void process(nibashared::message_send& req);
+    void process(nibashared::message_echo &req);
+    void process(nibashared::message_send &req);
     const nibashared::sessionstate &get_session();
 
 private:
@@ -38,7 +39,7 @@ private:
     nibashared::sessionstate session_;
     boost::asio::yield_context &yield_;
     db_accessor &db_;
-    session_map& ss_map_;
+    session_map &ss_map_;
     session_wptr ss_wptr_;
 };
 } // namespace nibaserver

--- a/server/server_processor.h
+++ b/server/server_processor.h
@@ -4,6 +4,7 @@
 #include "logger.h"
 #include "message.h"
 #include "sessiondata.h"
+#include "session_map.h"
 
 #include <boost/asio/spawn.hpp>
 #include <chrono>
@@ -11,8 +12,10 @@
 
 namespace nibaserver {
 class server_processor {
+using session_wptr = std::weak_ptr<server_session>;
+
 public:
-    server_processor(boost::asio::yield_context &yield, nibaserver::db_accessor &db);
+    server_processor(boost::asio::yield_context &yield, db_accessor &db, session_map& ss_map, session_wptr ss_wptr);
     ~server_processor() = default;
     // dispatch is responsible to handle all the type conversion, make the whatever calls
     // and then finally return the serialized message
@@ -26,12 +29,16 @@ public:
     void process(nibashared::message_learnmagic &req);
     void process(nibashared::message_fusemagic &req);
     void process(nibashared::message_reordermagic &req);
+    void process(nibashared::message_echo& req);
+    void process(nibashared::message_send& req);
     const nibashared::sessionstate &get_session();
 
 private:
     logger logger_;
     nibashared::sessionstate session_;
     boost::asio::yield_context &yield_;
-    nibaserver::db_accessor &db_;
+    db_accessor &db_;
+    session_map& ss_map_;
+    session_wptr ss_wptr_;
 };
 } // namespace nibaserver

--- a/server/server_session.cpp
+++ b/server/server_session.cpp
@@ -53,7 +53,7 @@ void server_session::go() {
                 nibautil::stopwatch stopwatch;
                 // process request and send out response
                 std::string response = processor.dispatch(request_str);
-                ws_.async_write(boost::asio::buffer(response), yield);
+                write(std::move(response));
                 BOOST_LOG_SEV(logger_, sev::info)
                     << "request processed in " << stopwatch.elapsed_ms() << "ms";
             }

--- a/server/server_session.h
+++ b/server/server_session.h
@@ -6,9 +6,8 @@
 
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/spawn.hpp>
-#include <boost/asio/ssl/stream.hpp>
-#include <boost/asio/steady_timer.hpp>
 #include <boost/beast/core.hpp>
+#include <boost/beast/ssl.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/beast/websocket/ssl.hpp>
 
@@ -22,21 +21,11 @@ public:
     void go();
 
 private:
-    enum class pingstate : char {
-        responsive = 0,
-        onhold = 1,
-    };
-    static constexpr int TIMEOUT = 15; // in seconds
-
     boost::asio::io_context &ioc_;
     boost::asio::io_context::strand strand_;
-    boost::asio::ip::tcp::socket socket_;
-    boost::beast::websocket::stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket &>> ws_;
-    boost::asio::steady_timer timer_;
+    boost::beast::websocket::stream<boost::beast::ssl_stream<boost::beast::tcp_stream>> ws_;
     nibaserver::db_accessor db_;
     logger logger_;
-    bool close_down_ = false;
-    pingstate ping_state_ = pingstate::responsive;
 };
 
 } // namespace nibaserver

--- a/server/server_session.h
+++ b/server/server_session.h
@@ -27,7 +27,7 @@ public:
 
     // Note this call is thread safe
     // The queue is protected by the strand_
-    void write(std::string str);
+    void write(std::string name, std::string str);
 
 private:
     boost::asio::io_context &ioc_;

--- a/server/server_session.h
+++ b/server/server_session.h
@@ -25,29 +25,9 @@ public:
     ~server_session();
     void go();
 
-    void write(std::string str) {
-        // Note this call is thread safe
-        // The queue is protected by the strand_
-        BOOST_LOG_SEV(logger_, boost::log::trivial::debug) << "write called";
-        boost::asio::spawn(strand_, [this, str{std::move(str)},
-                                     self{shared_from_this()}](boost::asio::yield_context yield) {
-            write_queue_.emplace(std::move(str));
-            BOOST_LOG_SEV(logger_, boost::log::trivial::debug) << "str enqueued";
-            if (write_queue_.size() != 1) {
-                return;
-                // Don't do anything, someone will handle it
-            }
-            for (;;) {
-                if (write_queue_.empty()) {
-                    return;
-                }
-                // write it
-                ws_.async_write(boost::asio::buffer(write_queue_.front()), yield);
-                // pop after we are done
-                write_queue_.pop();
-            }
-        });
-    }
+    // Note this call is thread safe
+    // The queue is protected by the strand_
+    void write(std::string str);
 
 private:
     boost::asio::io_context &ioc_;

--- a/server/server_session.h
+++ b/server/server_session.h
@@ -3,6 +3,7 @@
 #include "db_accessor.h"
 #include "global_defs.h"
 #include "logger.h"
+#include "session_map.h"
 
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/spawn.hpp>
@@ -11,21 +12,51 @@
 #include <boost/beast/websocket.hpp>
 #include <boost/beast/websocket/ssl.hpp>
 
+#include <queue>
+#include <string>
+
 namespace nibaserver {
 
 class server_session : public std::enable_shared_from_this<server_session> {
 public:
     server_session(boost::asio::io_context &ioc, boost::asio::ip::tcp::socket &&socket,
-                   boost::asio::ssl::context &ctx, nibaserver::db_accessor &&db);
+                   boost::asio::ssl::context &ctx, nibaserver::db_accessor &&db,
+                   session_map &ss_map);
     ~server_session();
     void go();
+
+    void write(std::string str) {
+        // Note this call is thread safe
+        // The queue is protected by the strand_
+        BOOST_LOG_SEV(logger_, boost::log::trivial::debug) << "write called";
+        boost::asio::spawn(strand_, [this, str{std::move(str)},
+                                     self{shared_from_this()}](boost::asio::yield_context yield) {
+            write_queue_.emplace(std::move(str));
+            BOOST_LOG_SEV(logger_, boost::log::trivial::debug) << "str enqueued";
+            if (write_queue_.size() != 1) {
+                return;
+                // Don't do anything, someone will handle it
+            }
+            for (;;) {
+                if (write_queue_.empty()) {
+                    return;
+                }
+                // write it
+                ws_.async_write(boost::asio::buffer(write_queue_.front()), yield);
+                // pop after we are done
+                write_queue_.pop();
+            }
+        });
+    }
 
 private:
     boost::asio::io_context &ioc_;
     boost::asio::io_context::strand strand_;
     boost::beast::websocket::stream<boost::beast::ssl_stream<boost::beast::tcp_stream>> ws_;
     nibaserver::db_accessor db_;
+    session_map &ss_map_;
     logger logger_;
+    std::queue<std::string> write_queue_;
 };
 
 } // namespace nibaserver

--- a/server/session_map.cpp
+++ b/server/session_map.cpp
@@ -7,15 +7,12 @@ namespace nibaserver {
 
 bool session_map::write(const std::string &name, std::string &&data) {
     std::lock_guard<std::mutex> guard(mutex_);
-    std::cout << "writing\n";
     if (auto iter = map_.find(name); iter != map_.end()) {
-        std::cout << name << " is found in session map\n";
         if (auto ptr = iter->second.lock()) {
             ptr->write(std::move(data));
             return true;
         }
     }
-    std::cout << "write to " << name << " failed\n";
     return false;
 }
 
@@ -40,7 +37,6 @@ bool session_map::register_session(const std::string &name, session_wptr wptr) {
         }
     }
     map_.emplace(name, wptr);
-    std::cout << name << " is online\n";
     return true;
 }
 

--- a/server/session_map.cpp
+++ b/server/session_map.cpp
@@ -1,0 +1,47 @@
+#include "session_map.h"
+#include "server_session.h"
+
+#include <iostream>
+
+namespace nibaserver {
+
+bool session_map::write(const std::string &name, std::string &&data) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    std::cout << "writing\n";
+    if (auto iter = map_.find(name); iter != map_.end()) {
+        std::cout << name << " is found in session map\n";
+        if (auto ptr = iter->second.lock()) {
+            ptr->write(std::move(data));
+            return true;
+        }
+    }
+    std::cout << "write to " << name << " failed\n";
+    return false;
+}
+
+void session_map::cleanup() {
+    std::lock_guard<std::mutex> guard(mutex_);
+    for (auto it = map_.begin(); it != map_.end();) {
+        if (it->second.expired()) {
+            it = map_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+bool session_map::register_session(const std::string &name, session_wptr wptr) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (auto iter = map_.find(name); iter != map_.end()) {
+        if (!iter->second.expired()) {
+            return false;
+        } else {
+            map_.erase(iter);
+        }
+    }
+    map_.emplace(name, wptr);
+    std::cout << name << " is online\n";
+    return true;
+}
+
+} // namespace nibaserver

--- a/server/session_map.cpp
+++ b/server/session_map.cpp
@@ -9,7 +9,7 @@ bool session_map::write(const std::string &name, std::string &&data) {
     std::shared_lock lock{mutex_};
     if (auto iter = map_.find(name); iter != map_.end()) {
         if (auto ptr = iter->second.lock()) {
-            ptr->write(std::move(data));
+            ptr->write(name, std::move(data));
             return true;
         }
     }
@@ -38,6 +38,13 @@ bool session_map::register_session(const std::string &name, session_wptr wptr) {
     }
     map_.emplace(name, wptr);
     return true;
+}
+
+void session_map::remove(const std::string& name) {
+    std::unique_lock{mutex_};
+    if (auto iter = map_.find(name); iter != map_.end()) {
+        map_.erase(iter);
+    }
 }
 
 } // namespace nibaserver

--- a/server/session_map.h
+++ b/server/session_map.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "logger.h"
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace nibaserver {
+
+class server_session;
+
+// A map of user_id -> session ptr
+// Needs to be thread safe
+
+// forward declare as server_session also need a session_map
+
+class session_map {
+public:
+    using session_wptr = std::weak_ptr<server_session>;
+
+    session_map() = default;
+    // TODO delete copy constructor
+
+    // Write to session of given name, returns whether person is online
+    // (eg. session exists and not yet destroyed)
+    bool write(const std::string &name, std::string &&data);
+
+    // Clean up, remove empty weak_ptrs, need a timer to run this periodically
+    // not a huge concern for now
+    void cleanup();
+
+    // Register, session
+    // Once user logs in properly, add to map_
+    // if a valid entry exists, then deny the login
+    bool register_session(const std::string &, session_wptr wptr);
+
+private:
+    std::mutex mutex_;
+    std::unordered_map<std::string, session_wptr> map_;
+    logger logger_;
+};
+
+} // namespace nibaserver

--- a/server/session_map.h
+++ b/server/session_map.h
@@ -3,7 +3,7 @@
 #include "logger.h"
 
 #include <memory>
-#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 
@@ -38,7 +38,7 @@ public:
     bool register_session(const std::string &, session_wptr wptr);
 
 private:
-    std::mutex mutex_;
+    std::shared_mutex mutex_;
     std::unordered_map<std::string, session_wptr> map_;
     logger logger_;
 };

--- a/server/session_map.h
+++ b/server/session_map.h
@@ -21,7 +21,8 @@ public:
     using session_wptr = std::weak_ptr<server_session>;
 
     session_map() = default;
-    // TODO delete copy constructor
+    session_map(const session_map &) = delete;
+    session_map &operator=(const session_map &) = delete;
 
     // Write to session of given name, returns whether person is online
     // (eg. session exists and not yet destroyed)

--- a/server/session_map.h
+++ b/server/session_map.h
@@ -35,7 +35,10 @@ public:
     // Register, session
     // Once user logs in properly, add to map_
     // if a valid entry exists, then deny the login
-    bool register_session(const std::string &, session_wptr wptr);
+    bool register_session(const std::string &name, session_wptr wptr);
+
+    // Attempt to remove a session, usually the session itself on destruction
+    void remove(const std::string& name);
 
 private:
     std::shared_mutex mutex_;

--- a/shared/message.cpp
+++ b/shared/message.cpp
@@ -299,26 +299,36 @@ void nibashared::message_reordermagic::from_request(const nlohmann::json &j) {
     j.at("equipped_magic_ids").get_to(equipped_magic_ids);
 }
 
-nibashared::message_echo::message_echo(std::string echo_str) : echo_str(std::move(echo_str)) {}
+nibashared::message_echo::message_echo(std::string echo_str, std::string sender) :
+    echo_str{std::move(echo_str)}, sender{std::move(sender)} {}
 
 bool nibashared::message_echo::validate(const nibashared::sessionstate &) { return true; }
 
-nlohmann::json nibashared::message_echo::create_response() { return {{"echo_str", echo_str}}; }
+nlohmann::json nibashared::message_echo::create_response() {
+    return {{"echo_str", echo_str}, {"sender", sender}};
+}
 
-nlohmann::json nibashared::message_echo::create_request() { return {{"echo_str", echo_str}}; }
+nlohmann::json nibashared::message_echo::create_request() {
+    return {{"echo_str", echo_str}, {"sender", sender}};
+}
 
 void nibashared::message_echo::merge_response(const nlohmann::json &j) {
     j.at("echo_str").get_to(echo_str);
+    j.at("sender").get_to(sender);
 }
 
 void nibashared::message_echo::from_request(const nlohmann::json &j) {
     j.at("echo_str").get_to(echo_str);
+    j.at("sender").get_to(sender);
 }
 
 nibashared::message_send::message_send(std::string name, std::string message) :
     name{std::move(name)}, message{std::move(message)} {}
 
-bool nibashared::message_send::validate(const nibashared::sessionstate &) {
+bool nibashared::message_send::validate(const nibashared::sessionstate &session) {
+    if (session.state == nibashared::gamestate::prelogin) {
+        return false;
+    }
     if (message.size() > 256) {
         // Message too long
         return false;

--- a/shared/message.cpp
+++ b/shared/message.cpp
@@ -8,10 +8,10 @@ namespace nibashared {
 
 using nlohmann::json;
 
-message_register::message_register(std::string &&id, std::string &&password) :
+message_registration::message_registration(std::string &&id, std::string &&password) :
     id(std::move(id)), password(std::move(password)) {}
 
-bool message_register::validate(const nibashared::sessionstate &session) {
+bool message_registration::validate(const nibashared::sessionstate &session) {
     // TODO: throw error with error code?
     if (session.state != nibashared::gamestate::prelogin)
         return false;
@@ -22,13 +22,13 @@ bool message_register::validate(const nibashared::sessionstate &session) {
     return true;
 }
 
-json message_register::create_response() { return {}; }
+json message_registration::create_response() { return {}; }
 
 // this is not used
-json message_register::create_request() { return {{"id", id}, {"password", password}}; }
-void message_register::merge_response(const json &j) { (void)j; }
+json message_registration::create_request() { return {{"id", id}, {"password", password}}; }
+void message_registration::merge_response(const json &j) { (void)j; }
 
-void message_register::from_request(const json &j) {
+void message_registration::from_request(const json &j) {
     j.at("id").get_to(id);
     j.at("password").get_to(password);
 }

--- a/shared/message.cpp
+++ b/shared/message.cpp
@@ -293,10 +293,50 @@ nlohmann::json nibashared::message_reordermagic::create_request() {
     return {{"equipped_magic_ids", equipped_magic_ids}};
 }
 
-void nibashared::message_reordermagic::merge_response(const nlohmann::json &j) { (void)j; }
+void nibashared::message_reordermagic::merge_response(const nlohmann::json &) {}
 
 void nibashared::message_reordermagic::from_request(const nlohmann::json &j) {
     j.at("equipped_magic_ids").get_to(equipped_magic_ids);
+}
+
+nibashared::message_echo::message_echo(std::string echo_str) : echo_str(std::move(echo_str)) {}
+
+bool nibashared::message_echo::validate(const nibashared::sessionstate &) { return true; }
+
+nlohmann::json nibashared::message_echo::create_response() { return {{"echo_str", echo_str}}; }
+
+nlohmann::json nibashared::message_echo::create_request() { return {{"echo_str", echo_str}}; }
+
+void nibashared::message_echo::merge_response(const nlohmann::json &j) {
+    j.at("echo_str").get_to(echo_str);
+}
+
+void nibashared::message_echo::from_request(const nlohmann::json &j) {
+    j.at("echo_str").get_to(echo_str);
+}
+
+nibashared::message_send::message_send(std::string name, std::string message) :
+    name{std::move(name)}, message{std::move(message)} {}
+
+bool nibashared::message_send::validate(const nibashared::sessionstate &) {
+    if (message.size() > 256) {
+        // Message too long
+        return false;
+    }
+    return true;
+}
+
+nlohmann::json nibashared::message_send::create_response() { return {}; }
+
+nlohmann::json nibashared::message_send::create_request() {
+    return {{"name", name}, {"message", message}};
+}
+
+void nibashared::message_send::merge_response(const nlohmann::json &) {}
+
+void nibashared::message_send::from_request(const nlohmann::json &j) {
+    j.at("name").get_to(name);
+    j.at("message").get_to(message);
 }
 
 } // namespace nibashared

--- a/shared/message.h
+++ b/shared/message.h
@@ -200,7 +200,7 @@ struct message_echo : public base_message<message_echo> {
     const message::type type = message::type::echo;
 
     message_echo() = default;
-    explicit message_echo(std::string echo_str, std::string sender);
+    message_echo(std::string echo_str, std::string sender);
     bool validate(const nibashared::sessionstate &session);
     nlohmann::json create_response();
     nlohmann::json create_request();
@@ -214,7 +214,7 @@ struct message_echo : public base_message<message_echo> {
 struct message_send : public base_message<message_send> {
     const message::type type = message::type::send;
     message_send() = default;
-    explicit message_send(std::string name, std::string message);
+    message_send(std::string name, std::string message);
     bool validate(const nibashared::sessionstate &session);
     nlohmann::json create_response();
     nlohmann::json create_request();

--- a/shared/message.h
+++ b/shared/message.h
@@ -200,7 +200,7 @@ struct message_echo : public base_message<message_echo> {
     const message::type type = message::type::echo;
 
     message_echo() = default;
-    explicit message_echo(std::string echo_str);
+    explicit message_echo(std::string echo_str, std::string sender);
     bool validate(const nibashared::sessionstate &session);
     nlohmann::json create_response();
     nlohmann::json create_request();
@@ -208,6 +208,7 @@ struct message_echo : public base_message<message_echo> {
     void from_request(const nlohmann::json &j);
 
     std::string echo_str;
+    std::string sender;
 };
 
 struct message_send : public base_message<message_send> {

--- a/test/config.json
+++ b/test/config.json
@@ -1,0 +1,7 @@
+{
+    "host": "0.0.0.0",
+    "port": 19999,
+    "threads": 1,
+    "static_conn_str": "dbname=niba_static user=postgres",
+    "player_conn_str": "dbname=niba user=postgres"
+}

--- a/test/config.json
+++ b/test/config.json
@@ -1,7 +1,7 @@
 {
     "host": "0.0.0.0",
     "port": 19999,
-    "threads": 1,
+    "threads": 4,
     "static_conn_str": "dbname=niba_static user=postgres",
     "player_conn_str": "dbname=niba user=postgres"
 }

--- a/test/test_latency.py
+++ b/test/test_latency.py
@@ -38,14 +38,14 @@ try:
     procs = []
     stderrs = []
 
-    input_bytes = b'register niba%d doctorniba\nlogin niba%d doctorniba\ncreate nibadan%d m 1 1 2 1\nlearnmagic 1\nlearnmagic 2\nfusemagic 2 1\nreordermagic 2\nfight 1\nfight 1\nfight 1\nexit\n'
+    input_bytes = b'register niba%d doctorniba\nlogin niba%d doctorniba\ncreate nibadan%d m 1 1 2 1\nsend nibadan%d helloworld\nlearnmagic 1\nlearnmagic 2\nfusemagic 2 1\nreordermagic 2\nfight 1\nfight 1\nfight 1\nexit\n'
     # for j in range(100):
     #     input_bytes += b'fight 1\n'
 
     start = time.time()
 
     for i in range(clients):
-        proc = run_client(input_bytes % (i, i, i))
+        proc = run_client(input_bytes % (i, i, i, i-1))
         procs.append(proc)
 
     for proc in procs:
@@ -60,14 +60,18 @@ try:
         # print(stderr)
         time = 0
         requests = 0
-        for latency in stderr.split(b'\n'):
-            if latency == b'':
-                continue
-            time += float(latency)
-            requests += 1
-        avg = time / requests
-        # print(avg, 'ms')
-        total += avg
+        try:
+            for latency in stderr.split(b'\n'):
+                if latency == b'':
+                    continue
+                time += float(latency)
+                requests += 1
+            avg = time / requests
+            # print(avg, 'ms')
+            total += avg
+        except Exception as e:
+            print(stderr)
+            raise e
 
     print('average wait per request', total / clients, 'ms')
     print('overall', end - start, 's')

--- a/test/test_latency.py
+++ b/test/test_latency.py
@@ -80,9 +80,14 @@ try:
             print(stderr)
             # raise e
 
+    # stdout, stderr = niba0.communicate()
+    # print(stdout)
+    niba0.stdin.write("\nexit\n")
+
     print('average wait per request', total / clients, 'ms')
     print('overall', end - start, 's')
-    
+
+
 except Exception as e:
     print(e)
 

--- a/test/test_latency.py
+++ b/test/test_latency.py
@@ -19,7 +19,7 @@ clients = 100
 if len(sys.argv) > 1:
     clients = int(sys.argv[1])
 
-server = subprocess.Popen([dir_path + '/niba-server'], cwd=dir_path)
+server = subprocess.Popen([dir_path + '/niba-server', 'config.json'], cwd=dir_path)
 time.sleep(1)
 
 
@@ -38,14 +38,16 @@ try:
     procs = []
     stderrs = []
 
-    input_bytes = b'register niba%d doctorniba\nlogin niba%d doctorniba\ncreate nibadan%d m 1 1 2 1\nsend nibadan%d helloworld\nlearnmagic 1\nlearnmagic 2\nfusemagic 2 1\nreordermagic 2\nfight 1\nfight 1\nfight 1\nexit\n'
+    input_bytes = b'register niba%d doctorniba\nlogin niba%d doctorniba\ncreate nibadan%d m 1 1 2 1\nsend nibadan helloworld\nlearnmagic 1\nlearnmagic 2\nfusemagic 2 1\nreordermagic 2\nfight 1\nfight 1\nfight 1\nexit\n'
     # for j in range(100):
     #     input_bytes += b'fight 1\n'
 
     start = time.time()
 
+    niba0 = run_client(b'register niba doctorniba\nlogin niba doctorniba\ncreate nibadan m 1 1 2 1\ntimeout 10\nexit\n')
+
     for i in range(clients):
-        proc = run_client(input_bytes % (i, i, i, i-1))
+        proc = run_client(input_bytes % (i, i, i))
         procs.append(proc)
 
     for proc in procs:
@@ -75,6 +77,8 @@ try:
 
     print('average wait per request', total / clients, 'ms')
     print('overall', end - start, 's')
+
+    niba0.terminate()
 
 except Exception as e:
     print(e)

--- a/test/test_latency.py
+++ b/test/test_latency.py
@@ -26,8 +26,9 @@ time.sleep(1)
 def run_client(input_bytes):
     proc = subprocess.Popen([dir_path + '/niba-client'],
                             stdin=subprocess.PIPE,
-                            stdout=subprocess.DEVNULL,
+                            stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
+                            universal_newlines=True,
                             cwd=dir_path)
     proc.stdin.write(input_bytes)
     proc.stdin.flush()
@@ -36,35 +37,37 @@ def run_client(input_bytes):
 
 try:
     procs = []
+    stdouts = []
     stderrs = []
 
-    input_bytes = b'register niba%d doctorniba\nlogin niba%d doctorniba\ncreate nibadan%d m 1 1 2 1\nsend nibadan helloworld\nlearnmagic 1\nlearnmagic 2\nfusemagic 2 1\nreordermagic 2\nfight 1\nfight 1\nfight 1\nexit\n'
+    input_bytes = 'register niba%d doctorniba\nlogin niba%d doctorniba\ncreate nibadan%d m 1 1 2 1\nsend nibadan helloworld\nlearnmagic 1\nlearnmagic 2\nfusemagic 2 1\nreordermagic 2\nfight 1\nfight 1\nfight 1\nexit\n'
     # for j in range(100):
     #     input_bytes += b'fight 1\n'
 
     start = time.time()
 
-    niba0 = run_client(b'register niba doctorniba\nlogin niba doctorniba\ncreate nibadan m 1 1 2 1\ntimeout 10\nexit\n')
+    niba0 = run_client('register niba doctorniba\nlogin niba doctorniba\ncreate nibadan m 1 1 2 1\ntimeout 10\nexit\n')
 
     for i in range(clients):
         proc = run_client(input_bytes % (i, i, i))
         procs.append(proc)
 
     for proc in procs:
-        _, stderr = proc.communicate()
+        stdout, stderr = proc.communicate()
         # stderr are exclusively response timings
+        stdouts.append(stdout)
         stderrs.append(stderr)
 
     end = time.time()
 
     total = 0
-    for stderr in stderrs:
+    for stdout, stderr in zip(stdouts, stderrs):
         # print(stderr)
         time = 0
         requests = 0
         try:
-            for latency in stderr.split(b'\n'):
-                if latency == b'':
+            for latency in stderr.split('\n'):
+                if latency == '':
                     continue
                 time += float(latency)
                 requests += 1
@@ -72,16 +75,17 @@ try:
             # print(avg, 'ms')
             total += avg
         except Exception as e:
+            print('encountered exception')
+            print(stdout)
             print(stderr)
-            raise e
+            # raise e
 
     print('average wait per request', total / clients, 'ms')
     print('overall', end - start, 's')
-
-    niba0.terminate()
-
+    
 except Exception as e:
     print(e)
 
 finally:
+    niba0.terminate()
     server.kill()


### PR DESCRIPTION
- boost 1.70
- use beast built in ping pong timeout, will need more testing
- server: store map of sessions for lookup, write queue for "arbitrary" write to a session
- client: long running read coroutine to read one way message from server
- need better error handling on client side
- allow multithreading