### PR TITLE
remove ozo submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(niba)
 
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.12)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_CXX_COMPILER $ENV{CXX})
@@ -17,16 +17,18 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 set(Boost_USE_STATIC_LIBS ON)
 
 add_compile_definitions(BOOST_COROUTINES_NO_DEPRECATION_WARNING)
-add_compile_definitions(BOOST_HANA_CONFIG_ENABLE_STRING_UDL)
 # TODO: enable only for debug builds
 add_compile_definitions(DELAYFACTOR=0.1)
 
 SET(Boost_USE_STATIC_LIBS ON)
-find_package(Boost 1.70.0 REQUIRED COMPONENTS system context coroutine log log_setup regex)
+find_package(Boost 1.70.0 REQUIRED COMPONENTS context coroutine log log_setup regex system)
+
 find_package(nlohmann_json 3.3.0 REQUIRED)
 find_package(OpenSSL 1.1.0 REQUIRED)
-find_package(Threads REQUIRED)
+find_package(resource_pool REQUIRED) # resource_pool must be found before ozo
+find_package(ozo REQUIRED)
 find_package(PostgreSQL 10 REQUIRED)
+find_package(Threads REQUIRED)
 
 file(GLOB SHARED_SRC_LIST shared/*.cpp)
 file(GLOB SERVER_SRC_LIST server/*.cpp)
@@ -37,25 +39,19 @@ include_directories(shared/)
 add_executable(niba-server ${SERVER_SRC_LIST} ${SHARED_SRC_LIST})
 add_executable(niba-client ${CLIENT_SRC_LIST} ${SHARED_SRC_LIST})
 
-target_include_directories(niba-server PRIVATE 
-    ${PostgreSQL_INCLUDE_DIRS}
-    ozo/include/ 
-    ozo/contrib/resource_pool/include
-)
-
 target_compile_definitions(niba-client PUBLIC NIBACLIENT)
 
 set(LINK_LIBS 
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
-    Boost::system
     Boost::context
     Boost::coroutine
     Boost::log
     Boost::log_setup
     Boost::regex
-    Threads::Threads
-    nlohmann_json::nlohmann_json)
+    Boost::system
+    nlohmann_json::nlohmann_json
+    Threads::Threads)
 
-target_link_libraries(niba-server ${LINK_LIBS} ${PostgreSQL_LIBRARIES})
+target_link_libraries(niba-server ${LINK_LIBS} elsid::resource_pool ozo ${PostgreSQL_LIBRARIES})
 target_link_libraries(niba-client ${LINK_LIBS})


### PR DESCRIPTION
ozo added target/find_package support recently (eg. need to install [ozo](https://github.com/yandex/ozo)&[resource_pool](https://github.com/elsid/resource_pool)), thinking of removing the submodule dependency

🤔 🤔 do not merge yet
